### PR TITLE
Make DavTransmitor::m_mutex mutable

### DIFF
--- a/FFdynamic/davBasis/davTransmitor.h
+++ b/FFdynamic/davBasis/davTransmitor.h
@@ -260,7 +260,7 @@ class DavTransmitor : public std::enable_shared_from_this<DavTransmitor<Load, Ad
    private:
     string m_logtag;
     Address m_selfAddress;
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     std::condition_variable m_expectCV;
     vector<Address> m_senderAddrs;
     std::multimap<Address, shared_ptr<Transmitor>> m_senderTransmitor;


### PR DESCRIPTION
Fixes https://github.com/Xingtao/FFdynamic/issues/28

By marking the mutex as `mutable`, the `const` method `curLoadNum` compiles correctly on Clang. The only reason it compiled before is because I assume the author was using GCC, which only complains if `DavTransmitor` is actually instantiated.